### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Removes all Bots.
 
 ### utils.setTickRate(value) <span style="color:red">DEPRECATED</span>
 
-Deprecated in favor of `system.setTickRate`   
+Deprecated in favor of `system.setTickDuration(value)`   
 ~~Sets the tick rate to value (in milliseconds)~~
 
 ### utils.getTickRate() <span style="color:red">DEPRECATED</span>
 
-Deprecated in favor of `system.getTickRate`   
+Deprecated in favor of `system.getTickDuration()`   
 ~~Gets the current tick rate~~
 
 ### utils.setSocketUpdateRate(value)


### PR DESCRIPTION
fixing typos

here's the cli output of why the old text was wrong:

> utils.getTickRate()
getTickRate has been deprecated and will be removed in future versions, please use system.getTickDuration instead.
> system.getTickDuration()
5
> utils.setTickRate()
setTickRate has been deprecated and will be removed in future versions, please use system.setTickDuration instead.