### PR TITLE
Fix compat with Node 10

### DIFF
--- a/lib/services/importMap/utils.js
+++ b/lib/services/importMap/utils.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const axios = require('axios')
-const { mkdir } = require('fs/promises')
 const fs = require('fs').promises
 
 module.exports = config => {
@@ -10,8 +9,8 @@ module.exports = config => {
     async importMap (map) {
       const mapDir = path.resolve(process.env.ASSET_DIR, 'map')
       const mapZoomDir = path.resolve(process.env.ASSET_DIR, 'map/zoom2')
-      await mkdir(mapDir, { recursive: true })
-      await mkdir(mapZoomDir, { recursive: true })
+      await fs.mkdir(mapDir, { recursive: true })
+      await fs.mkdir(mapZoomDir, { recursive: true })
       const cliMap = require('@screeps/backend/lib/cli/map')
       const log = (...a) => console.log('[ImportMap]', ...a)
       if (!config.mongo) {


### PR DESCRIPTION
Confirmed that changing that causes the `utils.importMap` command to show up again in `help(utils)`