### PR TITLE
Terminal rather than storage decides whether a room is established.

### DIFF
--- a/lib/services/warpath/battledetect.js
+++ b/lib/services/warpath/battledetect.js
@@ -174,14 +174,14 @@ class BattleDetect {
     if (roomLevel < 6) {
       return ROOM_DEVELOPING
     }
-    if (!roomObjects.storage && !roomObjects.terminal) {
+    if (!roomObjects.terminal) {
       return ROOM_DEVELOPING
     }
     const towers = roomObjects.tower.length
     if (towers.length < 2) {
       return ROOM_DEVELOPING
     }
-    if (roomLevel < 8 || roomObjects.tower.length < 5) {
+    if (roomLevel < 8 || roomObjects.tower.length < 5 || !roomObjects.storage) {
       return ROOM_ESTABLISHED
     }
     return ROOM_FORTIFIED

--- a/warpath-classifications.md
+++ b/warpath-classifications.md
@@ -9,9 +9,9 @@ Any classification is automatically upgraded to the next level (including from 5
 ​
 * Neutral - No Owners or Reservers
 * Undefended - Room has no towers.
-* Developing - Is less than RCL6, or does not have at least two towers or storage.
-* Established - At least RCL6 with at least two towers and storage (or terminal).
-* Fortified - At least RCL8 with at least five towers and storage (or terminal).
+* Developing - Is less than RCL6, or does not have at least two towers and terminal.
+* Established - At least RCL6 with at least two towers and terminal.
+* Fortified - At least RCL8 with at least five towers, storage and terminal.
 ​
 ​
 ## Class 5


### PR DESCRIPTION
A room with a terminal can be supported from the market or from another base. IMO this grants a far larger leap in defensive capability than the presence of a storage.