### PR TITLE
Avoid map re-imports

### DIFF
--- a/lib/services/importMap/backend.js
+++ b/lib/services/importMap/backend.js
@@ -3,9 +3,11 @@ module.exports = (config) => {
 
   config.utils.on('config:update:map', async (urlOrMapId) => {
     const currentMap = await env.get(env.keys.MAP_URL)
-    if (currentMap && currentMap !== urlOrMapId) {
-      console.log(`Map value in config.yml has changed to ${urlOrMapId}, current map is ${currentMap}`)
-      console.log(`If you wish to apply this then call utils.importMap('${urlOrMapId}') manually or system.resetAllData() then restart server.`)
+    if (currentMap) {
+      if (currentMap !== urlOrMapId) {
+        console.log(`Map value in config.yml has changed to ${urlOrMapId}, current map is ${currentMap}`)
+        console.log(`If you wish to apply this then call utils.importMap('${urlOrMapId}') manually or system.resetAllData() then restart server.`)
+      }
       return
     }
     await config.utils.importMap(urlOrMapId)
@@ -13,9 +15,11 @@ module.exports = (config) => {
 
   config.utils.on('config:update:mapFile', async (filePath) => {
     const currentMap = await env.get(env.keys.MAP_URL)
-    if (currentMap && currentMap !== filePath) {
-      console.log(`Map value in config.yml has changed to ${filePath}, current map is ${currentMap}`)
-      console.log(`If you wish to apply this then call utils.importMapFile('${filePath}') manually or system.resetAllData() then restart server.`)
+    if (currentMap) {
+      if (currentMap !== filePath) {
+        console.log(`Map value in config.yml has changed to ${filePath}, current map is ${currentMap}`)
+        console.log(`If you wish to apply this then call utils.importMapFile('${filePath}') manually or system.resetAllData() then restart server.`)
+      }
       return
     }
     await config.utils.importMapFile(filePath)


### PR DESCRIPTION
There's a logic problem in the map config check that allows the map to be re-imported if it's equal to the configured map. This should prevent that while still logging for users that have attempted to change their map via the config file.