### PR TITLE
Quick changes to the whitelist

### DIFF
--- a/lib/services/whitelist/utils.js
+++ b/lib/services/whitelist/utils.js
@@ -3,9 +3,7 @@ module.exports = config => {
 
   Object.assign(config.utils, {
     async getWhitelist () {
-      const users = JSON.parse(await env.get(env.keys.WHITELIST) || '[]')
-      const usersList = users.join(', ')
-      return `Whitelisted users: ${usersList}`
+      return JSON.parse(await env.get(env.keys.WHITELIST) || '[]')
     },
     async addWhitelistUser (user) {
       user = user.toLowerCase()

--- a/lib/services/whitelist/utils.js
+++ b/lib/services/whitelist/utils.js
@@ -20,7 +20,7 @@ module.exports = config => {
       return `${user} removed from whitelist`
     }
   })
-  config.utils.getWhitelist._help = 'getWhitelist()'
-  config.utils.addWhitelistUser._help = 'addWhitelistUser(username)'
-  config.utils.removeWhitelistUser._help = 'removeWhitelistUser(username)'
+  config.utils.getWhitelist._help = 'getWhitelist() - Get the current whitelist object'
+  config.utils.addWhitelistUser._help = 'addWhitelistUser(username) - Add the given user to the whitelist'
+  config.utils.removeWhitelistUser._help = 'removeWhitelistUser(username) - Remove the give user from the whitelist'
 }


### PR DESCRIPTION
This adds the missing help for those commands, and changes `getWhitelist` to return the object directly.

This is mostly to make it simpler to manipulate from the CLI, as you can now forEach over that instead of having to poke at the `storage.env` value for those.