### PR TITLE
Revert axios to ^0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Alina Shumann",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.9.0",
+    "axios": "^0.19.0",
     "body-parser": "^2.2.0",
     "lodash": "^4.17.21",
     "ramda": "^0.30.1",


### PR DESCRIPTION
This PR reverts the axios dependency version from ^1.9.0 back to ^0.19.0, restoring it to the previous version for compatibility reasons.