### PR TITLE
Revert body-parser to ^1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.19.0",
-    "body-parser": "^2.2.0",
+    "body-parser": "^1.19.0",
     "lodash": "^4.17.21",
     "ramda": "^0.30.1",
     "screepsmod-admin-utils-ui": "^0.4.0",


### PR DESCRIPTION
This PR reverts the body-parser dependency version