### PR TITLE
Add cors and morgan services, modernize dependencies

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,2 @@
 patreon: ags131
-github: [ags131]
+github: [AlinaNova21]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Adam Shumann 2017
+Copyright (c) Alina Shumann 2026
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ config.yml example: (This can be the same file as screeps-launcher's config.yml)
 # Values set here will override any saved via CLI on server startup
 serverConfig: 
   map: random_1x2 # utils.importMap will be called automatically with this value, see utils.importMap above
+  mapFile: /path/to/map.json # Alternative to map: import from a local JSON file
   tickRate: 200
   socketUpdateRate: 200
   whitelist: # Does not restrict login, only restricts spawning
@@ -110,10 +111,29 @@ serverConfig:
     <h1>Welcome</h1>
     <div>Powered by screepsmod-admin-utils</div>
   statsToken: ...splusToken... # This enables submitting stats to S+ Grafana. Note: shardName MUST be set
+  market: # Config block passed to your market mod — see that mod's documentation for structure
+  features: # Custom features to expose to clients
+  - name: customFeature
+    version: 1
   gclToCPU: true
   maxCPU: 100
   baseCPU: 20
   stepCPU: 10
+  morgan: dev # HTTP request logging format: dev, combined, tiny, short, common. Absent or false = disabled
+  cors:
+    origins: # List of allowed origins; absent or empty disables CORS entirely
+    - https://example.com
+    - http://localhost:8080
+    allowedHeaders: # Optional — these are the defaults
+    - Authorization
+    - Content-Type
+    - X-Token
+    - X-Username
+    - X-Server-Password
+    exposedHeaders: # Optional — these are the defaults
+    - X-Token
+    - X-Username
+    - X-Server-Password
 ```
 
 ## Endpoints

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,11 +1,9 @@
 const authroute = require('@screeps/backend/lib/game/api/auth')
 const util = require('util')
 const fs = require('fs')
-const R = require('ramda')
-
 const readFile = util.promisify(fs.readFile)
 
-const indexById = R.indexBy(R.prop('_id'))
+const indexById = arr => Object.fromEntries(arr.map(o => [o._id, o]))
 
 module.exports = (config) => {
   config.backend.features = config.backend.features || []

--- a/lib/common.js
+++ b/lib/common.js
@@ -148,7 +148,7 @@ module.exports = (config) => {
       }
     },
     async banUser (username, remove = false) {
-      const user = await db.users.findOne({ username: username })
+      const user = await db.users.findOne({ username })
       if (!user) {
         return `Can't find user "${username}"`
       }
@@ -173,7 +173,7 @@ module.exports = (config) => {
       }
     },
     async unbanUser (username) {
-      const user = await db.users.findOne({ username: username })
+      const user = await db.users.findOne({ username })
       if (!user) {
         return `Can't find user "${username}"`
       } else if (user.active !== 0) {

--- a/lib/mise.toml
+++ b/lib/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "24"
+pnpm = "10"

--- a/lib/services/cors/backend.js
+++ b/lib/services/cors/backend.js
@@ -1,0 +1,43 @@
+/*  config.yml
+    cors:
+      origins: string[]        # list of allowed origins; absent/empty = CORS disabled
+      allowedHeaders: string[] # optional override
+      exposedHeaders: string[] # optional override
+*/
+
+const cors = require('cors')
+
+const DEFAULT_ALLOWED_HEADERS = ['Authorization', 'Content-Type', 'X-Token', 'X-Username', 'X-Server-Password']
+const DEFAULT_EXPOSED_HEADERS = ['X-Token', 'X-Username', 'X-Server-Password']
+const ALLOWED_METHODS = 'GET,HEAD,PUT,PATCH,POST,DELETE'
+
+module.exports = function (config) {
+  config.cors = {
+    origins: [],
+    allowedHeaders: DEFAULT_ALLOWED_HEADERS.slice(),
+    exposedHeaders: DEFAULT_EXPOSED_HEADERS.slice()
+  }
+
+  config.utils.on('config:update:cors', function (v) {
+    if (!v || typeof v !== 'object') return
+    config.cors.origins = Array.isArray(v.origins) ? v.origins : []
+    config.cors.allowedHeaders = v.allowedHeaders || DEFAULT_ALLOWED_HEADERS.slice()
+    config.cors.exposedHeaders = v.exposedHeaders || DEFAULT_EXPOSED_HEADERS.slice()
+  })
+
+  const corsMiddleware = cors(function (req, cb) {
+    const { origins, allowedHeaders, exposedHeaders } = config.cors
+    if (!origins || !origins.length) return cb(null, { origin: false })
+    cb(null, {
+      origin: origins,
+      methods: ALLOWED_METHODS,
+      allowedHeaders,
+      exposedHeaders,
+      preflightContinue: false
+    })
+  })
+
+  config.backend.on('expressPreConfig', function (app) {
+    app.use(corsMiddleware)
+  })
+}

--- a/lib/services/importMap/utils.js
+++ b/lib/services/importMap/utils.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const axios = require('axios')
 const fs = require('fs').promises
 
 const log = (...args) => console.log('[ImportMap]', ...args)
@@ -140,7 +139,7 @@ const getMapFromUrl = async (urlOrMapId) => {
   if (urlOrMapId.startsWith('random')) {
     const [, size] = urlOrMapId.split('_')
     const [width, height] = size.split('x').map(v => +v || 1)
-    const { data } = await axios.get('https://maps.screepspl.us/maps/index.json')
+    const data = await fetch('https://maps.screepspl.us/maps/index.json').then(r => r.json())
 
     const maps = Object.values(data).filter(m => +m.width === width && +m.height === height)
     if (!maps.length) {
@@ -154,7 +153,7 @@ const getMapFromUrl = async (urlOrMapId) => {
   if (url !== urlOrMapId) {
     log(`Importing map from: ${url}`)
   }
-  const { data: { rooms } } = await axios.get(url)
+  const { rooms } = await fetch(url).then(r => r.json())
   return rooms
 }
 
@@ -191,7 +190,7 @@ const exportMap = async (config) => {
     const room = {
       room: roomName,
       terrain: terrain.terrain,
-      objects: objects
+      objects
     }
     Object.assign(room, roomData)
     count++

--- a/lib/services/morgan/backend.js
+++ b/lib/services/morgan/backend.js
@@ -1,0 +1,21 @@
+/*  config.yml
+    morgan: dev  # any morgan format string; absent or false = disabled
+*/
+
+const morgan = require('morgan')
+
+const noop = (req, res, next) => next()
+
+module.exports = function (config) {
+  let morganMiddleware = noop
+
+  config.utils.on('config:update:morgan', function (v) {
+    morganMiddleware = v ? morgan(v) : noop
+  })
+
+  config.backend.on('expressPreConfig', function (app) {
+    app.use(function (req, res, next) {
+      morganMiddleware(req, res, next)
+    })
+  })
+}

--- a/lib/services/stats/cronjobs.js
+++ b/lib/services/stats/cronjobs.js
@@ -1,5 +1,3 @@
-const axios = require('axios')
-
 module.exports = config => {
   config.cronjobs.stats = [15, async () => {
     const { env } = config.common.storage
@@ -15,18 +13,13 @@ module.exports = config => {
         }, {})
       }
       delete stats.ticks.ticks
-      axios({
+      fetch('https://screepspl.us/api/stats/submit', {
         method: 'POST',
-        url: 'https://screepspl.us/api/stats/submit',
-        auth: {
-          username: 'token',
-          password: config.utils.statsToken
+        headers: {
+          Authorization: 'Basic ' + Buffer.from(`token:${config.utils.statsToken}`).toString('base64'),
+          'Content-Type': 'application/json'
         },
-        data: {
-          servers: {
-            [shard]: stats
-          }
-        }
+        body: JSON.stringify({ servers: { [shard]: stats } })
       })
     } catch (e) {
       console.error(e)

--- a/lib/services/warpath/wrapper.js
+++ b/lib/services/warpath/wrapper.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 // const ACTIVE_THRESHOLD = 0.5 * (60)
 // const DELETE_THRESHOLD = 5 * (60)
 
@@ -15,7 +13,10 @@ function init (conf) {
 
 const api = {
   async roomobjects (room, shard) {
-    return _.groupBy(await db['rooms.objects'].find({ room }), 'type')
+    return (await db['rooms.objects'].find({ room })).reduce((acc, o) => {
+      ;(acc[o.type] = acc[o.type] || []).push(o)
+      return acc
+    }, {})
   },
   async time (shard) {
     const gameTime = await env.get('gameTime')

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "screepsmod-admin-utils",
   "version": "1.35.1",
-  "description": "",
+  "description": "Admin utilities and services for Screeps Private Server",
   "repository": {
     "url": "https://github.com/ScreepsMods/screepsmod-admin-utils"
   },
   "main": "index.js",
   "scripts": {
-    "test": "standard",
-    "2npm": "publish"
+    "test": "standard"
   },
   "devDependencies": {
     "@screeps/backend": "^3.2.6",
@@ -23,10 +22,9 @@
   "author": "Alina Shumann",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.0",
-    "body-parser": "^1.19.0",
-    "lodash": "^4.17.21",
-    "ramda": "^0.30.1",
+    "body-parser": "^2.2.2",
+    "cors": "^2.8.5",
+    "morgan": "^1.10.0",
     "screepsmod-admin-utils-ui": "^0.4.0",
     "yamljs": "^0.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,15 @@ importers:
 
   .:
     dependencies:
-      axios:
-        specifier: ^1.9.0
-        version: 1.9.0
       body-parser:
-        specifier: ^2.2.0
-        version: 2.2.0
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
-      ramda:
-        specifier: ^0.30.1
-        version: 0.30.1
+        specifier: ^2.2.2
+        version: 2.2.2
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.6
+      morgan:
+        specifier: ^1.10.0
+        version: 1.10.1
       screepsmod-admin-utils-ui:
         specifier: ^0.4.0
         version: 0.4.0
@@ -175,25 +172,23 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   brace-expansion@1.1.11:
@@ -238,10 +233,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -273,6 +264,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -315,6 +310,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -325,10 +329,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -582,22 +582,9 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
-    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -700,6 +687,10 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
@@ -707,8 +698,8 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -911,9 +902,6 @@ packages:
   lodash@3.10.1:
     resolution: {integrity: sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -949,9 +937,9 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mime-types@3.0.1:
-    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
-    engines: {node: '>= 0.6'}
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -963,6 +951,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  morgan@1.10.1:
+    resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
+    engines: {node: '>= 0.8.0'}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -1093,12 +1085,20 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
   on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -1215,9 +1215,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   publish@0.6.0:
     resolution: {integrity: sha512-eP+7Jvysc11/mG2pCHewDYn10UJsJV3CzgYnu4EHufs/ksTNVM3R/jPC4sZmNxJKdNJmFBw5Uuy2Az+19PJR8w==}
     hasBin: true
@@ -1244,15 +1241,12 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  ramda@0.30.1:
-    resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
 
   random-bytes@1.0.0:
     resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
@@ -1266,9 +1260,9 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
-  raw-body@3.0.0:
-    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
-    engines: {node: '>= 0.8'}
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -1414,6 +1408,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   steam-webapi@0.6.5:
@@ -1774,21 +1772,15 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  asynckit@0.4.0: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.9.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   balanced-match@1.0.2: {}
+
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   body-parser@1.20.3:
     dependencies:
@@ -1807,16 +1799,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.0:
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1
+      debug: 4.4.3
       http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.0
+      qs: 6.15.1
+      raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -1864,10 +1856,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   concat-map@0.0.1: {}
 
   content-disposition@0.5.4:
@@ -1890,6 +1878,11 @@ snapshots:
   cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1927,6 +1920,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -1940,8 +1937,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  delayed-stream@1.0.0: {}
 
   delegates@1.0.0: {}
 
@@ -2354,18 +2349,9 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.9: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  form-data@4.0.2:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -2480,13 +2466,21 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-parser-js@0.5.10: {}
 
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.6.3:
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -2697,8 +2691,6 @@ snapshots:
 
   lodash@3.10.1: {}
 
-  lodash@4.17.21: {}
-
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -2721,7 +2713,7 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mime-types@3.0.1:
+  mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
 
@@ -2732,6 +2724,16 @@ snapshots:
       brace-expansion: 1.1.11
 
   minimist@1.2.8: {}
+
+  morgan@1.10.1:
+    dependencies:
+      basic-auth: 2.0.1
+      debug: 2.6.9
+      depd: 2.0.0
+      on-finished: 2.3.0
+      on-headers: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ms@2.0.0: {}
 
@@ -2795,11 +2797,17 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
 
   on-headers@1.0.2: {}
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:
@@ -2904,8 +2912,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
-
   publish@0.6.0:
     dependencies:
       nopt: 3.0.6
@@ -2928,13 +2934,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.14.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
-
-  ramda@0.30.1: {}
 
   random-bytes@1.0.0: {}
 
@@ -2947,11 +2951,11 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  raw-body@3.0.0:
+  raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   react-is@16.13.1: {}
@@ -3169,6 +3173,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   steam-webapi@0.6.5:
     dependencies:
       qs: 1.2.2
@@ -3263,7 +3269,7 @@ snapshots:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
-      mime-types: 3.0.1
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- **CORS service** — integrates `screepsmod-cors` as a built-in service. Disabled by default; enabled by adding `cors.origins` to `config.yml`. Drops the need for a separate mod.
- **Morgan service** — adds optional HTTP request logging. Format configured via `morgan: dev` (or any morgan format string) in `config.yml`. Hot-reloadable, noop when absent.
- **Dependency modernization** — removed `axios` (replaced with native `fetch`), `lodash`, and `ramda` (replaced with native JS). Updated `body-parser` to v2.
- **Package cleanup** — updated description, license year, FUNDING.yml, removed stale `2npm` script, sorted dependencies.
- **README** — documents all previously undocumented config options: `mapFile`, `market`, `features`, `morgan`, `cors`.

## Config

```yaml
serverConfig:
  morgan: dev  # optional HTTP logging
  cors:
    origins:
      - https://example.com
```