### PR TITLE
New cronjobMgr service

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,9 +1,19 @@
+const assert = require('assert')
 const EventEmitter = require('events').EventEmitter
 const utils = require('@screeps/backend/lib/utils.js')
 const YAML = require('yamljs')
 const fs = require('fs')
 const util = require('util')
 const readFile = util.promisify(fs.readFile)
+
+function isEqual (a, b) {
+  try {
+    assert.deepStrictEqual(a, b)
+    return true
+  } catch {
+    return false
+  }
+}
 
 module.exports = (config) => {
   const { storage: { db, env, pubsub }, constants: C } = config.common
@@ -140,7 +150,7 @@ module.exports = (config) => {
         config.utils.config = conf
         config.utils.emit('config', conf)
         for (const [k, v] of Object.entries(conf)) {
-          if (lastConfig[k] !== v) {
+          if (!isEqual(lastConfig[k], v)) {
             config.utils.emit(`config:update:${k}`, v)
           }
         }

--- a/lib/common.js
+++ b/lib/common.js
@@ -155,6 +155,7 @@ module.exports = (config) => {
           }
         }
       } catch (err) {
+        console.error('Error reloading config:', err)
       }
     },
     async banUser (username, remove = false) {

--- a/lib/services/cronjobMgr/backend.js
+++ b/lib/services/cronjobMgr/backend.js
@@ -78,7 +78,14 @@ module.exports = config => {
     if (Date.now() - (jobData[2] || 0) > intervalSec * 1000) {
       log(`Running cronjob '${name}'`)
       jobData[2] = Date.now()
-      jobData[1]({ utils: backendUtils })
+      const run = jobData[1]
+      ;(async () => {
+        try {
+          await run({ utils: backendUtils })
+        } catch (err) {
+          log(`Cronjob '${name}' failed:`, err)
+        }
+      })()
     }
   }
 

--- a/lib/services/cronjobMgr/backend.js
+++ b/lib/services/cronjobMgr/backend.js
@@ -1,0 +1,103 @@
+const backendUtils = require('@screeps/backend/lib/utils.js')
+const cronjobsModule = require('@screeps/backend/lib/cronjobs.js')
+
+const log = (...args) => console.log('[cronjobMgr]', ...args)
+
+const isPositiveNumber = value => typeof value === 'number' && Number.isFinite(value) && value > 0
+
+module.exports = config => {
+  let cronjobMgrConfig = {}
+  /** After reloadConfig emits `config`; blocks cron tick until then (see common.js). */
+  let configLoaded = false
+
+  config.utils.on('config', conf => {
+    // can't use config:update:cronjobMgr because it might be missing
+    if (conf == null || typeof conf !== 'object') return
+    cronjobMgrConfig =
+      conf.cronjobMgr != null && typeof conf.cronjobMgr === 'object'
+        ? conf.cronjobMgr
+        : {}
+    configLoaded = true
+  })
+
+  const listCronjobs = backendUtils.withHelp([
+    'listCronjobs() - (admin-utils) List backend cronjobs',
+    function listCronjobs () {
+      if (!configLoaded) {
+        return 'Cronjobs: (no config yet — waiting for first reloadConfig / `config` emit)'
+      }
+      const jobs = config.cronjobs || {}
+      const names = Object.keys(jobs).sort((a, b) => a.localeCompare(b))
+      const rows = [['name', 'status', 'interval', 'lastRun']]
+      for (const name of names) {
+        const entry = jobs[name]
+        const jobState = cronjobMgrConfig[name]
+        if (!Array.isArray(entry) || typeof entry[1] !== 'function') continue
+
+        const [baselineIntervalSec, , lastTriggered] = entry
+        const disabled = jobState === false
+        const status = disabled ? 'disabled' : 'enabled'
+
+        const intervalStr =
+          !disabled && isPositiveNumber(jobState) && jobState !== baselineIntervalSec
+            ? `${jobState}s (${baselineIntervalSec}s)`
+            : `${baselineIntervalSec}s`
+
+        const lastRun =
+          typeof lastTriggered === 'number' && Number.isFinite(lastTriggered)
+            ? new Date(lastTriggered).toISOString()
+            : '—'
+
+        rows.push([name, status, intervalStr, lastRun])
+      }
+
+      const widths = rows[0].map((_, i) =>
+        Math.max(...rows.map(r => String(r[i]).length))
+      )
+      const lines = rows.map(r =>
+        r.map((cell, i) => String(cell).padEnd(widths[i])).join('  ')
+      )
+      return ['Cronjobs:', ...lines].join('\n')
+    }
+  ])
+
+  function runCronjobEntry (name, jobData, jobState) {
+    if (!Array.isArray(jobData) || typeof jobData[1] !== 'function') return
+
+    const baselineIntervalSec = jobData[0]
+
+    if (jobState === false) {
+      if (Date.now() - (jobData[2] || 0) > baselineIntervalSec * 1000) {
+        log(`Cronjob '${name}' disabled, skipping...`)
+        jobData[2] = Date.now()
+      }
+      return
+    }
+
+    const intervalSec = isPositiveNumber(jobState) ? jobState : baselineIntervalSec
+    if (Date.now() - (jobData[2] || 0) > intervalSec * 1000) {
+      log(`Running cronjob '${name}'`)
+      jobData[2] = Date.now()
+      jobData[1]({ utils: backendUtils })
+    }
+  }
+
+  // for obvious reasons, we need to run this cronjob at all times
+  const mandatoryCronjobs = ['screepsLauncherConfig']
+
+  cronjobsModule.run = function cronjobMgrRun () {
+    const jobs = config.cronjobs || {}
+    const overrides = cronjobMgrConfig
+
+    for (const [name, jobData] of Object.entries(jobs)) {
+      if (!configLoaded && !mandatoryCronjobs.includes(name)) continue
+      runCronjobEntry(name, jobData, overrides[name])
+    }
+  }
+
+  config.cli.on('cliSandbox', sandbox => {
+    sandbox.system = sandbox.system || {}
+    sandbox.system.listCronjobs = listCronjobs
+    sandbox.system._help = backendUtils.generateCliHelp('system.', sandbox.system)
+  })
+}


### PR DESCRIPTION
This adds a new service, adding a `cronjobMgr` section to the config file whose keys are cronjob names and values are either `true`, `false` or a number, overriding the cronjob's default state.

The idea is that if you don't want strongholds, or deposits, just set `genStrongholds: false`, `getDeposits: false` which would stop the server from processing those jobs. There's also a new `system.listCronjobs()` cli command to check on the state of everything.

Included is a small fix to the way we do config block comparisons, as the previous system would just have triggered the event every time because of the equality check used. Instead, do a deep comparison so we only update configs if there are different.