### PR TITLE
Fix the banned check in `fixAllowed`

### DIFF
--- a/lib/services/whitelist/cronjobs.js
+++ b/lib/services/whitelist/cronjobs.js
@@ -5,7 +5,11 @@ module.exports = (config) => {
     const WHITELIST = JSON.parse(await env.get(env.keys.WHITELIST) || '[]').map(u => u.toLowerCase())
     const users = await db.users.find()
     for (const user of users) {
-      const blocked = !(user.allowed || !user.banned || WHITELIST.length === 0 || (user.username && WHITELIST.includes(user.username.toLowerCase())))
+      const whitelistActive = WHITELIST.length > 0
+      const onWhitelist = Boolean(user.username && WHITELIST.includes(user.username.toLowerCase()))
+      const blocked =
+        Boolean(user.banned) ||
+        (whitelistActive && !user.bot && !onWhitelist)
       db.users.update({ _id: user._id }, { $set: { blocked } })
     }
   }]


### PR DESCRIPTION
The check didn't account for `user.banned` being undefined, which made the condition always true, breaking the whitelist application entirely.